### PR TITLE
Add a note about restrictions of Attribute values

### DIFF
--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -28,6 +28,9 @@ option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/metric
 message ResourceMetrics {
   // The resource for the metrics in this message.
   // If this field is not set then no resource info is known.
+  // The OpenTelemetry API specification further restricts the allowed value
+  // types for Attributes of the resource:
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes
   opentelemetry.proto.resource.v1.Resource resource = 1;
 
   // A list of metrics that originate from a resource.
@@ -320,6 +323,8 @@ enum DataPointFlags {
 message NumberDataPoint {
   // The set of key/value pairs that uniquely identify the timeseries from
   // where this point belongs. The list may be empty (may contain 0 elements).
+  // The OpenTelemetry API specification further restricts the allowed value types:
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
 
   // Labels is deprecated and will be removed soon.

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -379,6 +379,8 @@ message NumberDataPoint {
 message HistogramDataPoint {
   // The set of key/value pairs that uniquely identify the timeseries from
   // where this point belongs. The list may be empty (may contain 0 elements).
+  // The OpenTelemetry API specification further restricts the allowed value types:
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
 
   // Labels is deprecated and will be removed soon.
@@ -458,6 +460,8 @@ message HistogramDataPoint {
 message SummaryDataPoint {
   // The set of key/value pairs that uniquely identify the timeseries from
   // where this point belongs. The list may be empty (may contain 0 elements).
+  // The OpenTelemetry API specification further restricts the allowed value types:
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
 
   // Labels is deprecated and will be removed soon.
@@ -532,6 +536,8 @@ message Exemplar {
   // The set of key/value pairs that were filtered out by the aggregator, but
   // recorded alongside the original measurement. Only key/value pairs that were
   // filtered out by the aggregator should be included
+  // The OpenTelemetry API specification further restricts the allowed value types:
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes
   repeated opentelemetry.proto.common.v1.KeyValue filtered_attributes = 7;
 
   // Labels is deprecated and will be removed soon.

--- a/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/opentelemetry/proto/metrics/v1/metrics.proto
@@ -29,7 +29,7 @@ message ResourceMetrics {
   // The resource for the metrics in this message.
   // If this field is not set then no resource info is known.
   // The OpenTelemetry API specification further restricts the allowed value
-  // types for Attributes of the resource:
+  // types for Attributes of the Resource:
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes
   opentelemetry.proto.resource.v1.Resource resource = 1;
 


### PR DESCRIPTION
Adds a note about the restrictions for Attribute values, both in the Resource and for the data points. This should ensure that users and readers of the protobuf are aware of the restrictions (e.g. arbitrarily nested values are not allowed).