### PR TITLE
Make it possible to indicate partial success in an OTLP export response

### DIFF
--- a/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -42,4 +42,18 @@ message ExportLogsServiceRequest {
 }
 
 message ExportLogsServiceResponse {
+  // The details of a partially successfull export request.
+  // When the request is only partially successfull (due to e.g. invalid/bad data),
+  // the server MUST populate the details property with a developer-facing error
+  // message along with the number of accepted log records.
+  ExportLogsPartialSuccess details = 1;
+}
+
+message ExportLogsPartialSuccess {
+  // The number of accepted log records
+  int64 accepted_log_records = 1;
+
+  // A developer-facing human-readable error message in English. It should
+  // both explain the error and offer an actionable resolution to it.
+  string error_message = 2;
 }

--- a/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -42,4 +42,18 @@ message ExportMetricsServiceRequest {
 }
 
 message ExportMetricsServiceResponse {
+  // The details of a partially successfull export request.
+  // When the request is only partially successfull (due to e.g. invalid/bad data),
+  // the server MUST populate the details property with a developer-facing error
+  // message along with the number of accepted data points.
+  ExportMetricsPartialSuccess details = 1;
+}
+
+message ExportMetricsPartialSuccess {
+  // The number of accepted data points
+  int64 accepted_data_points = 1;
+
+  // A developer-facing human-readable error message in English. It should
+  // both explain the error and offer an actionable resolution to it.
+  string error_message = 2;
 }

--- a/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -42,4 +42,18 @@ message ExportTraceServiceRequest {
 }
 
 message ExportTraceServiceResponse {
+  // The details of a partially successfull export request.
+  // When the request is only partially successfull (due to e.g. invalid/bad data),
+  // the server MUST populate the details property with a developer-facing error
+  // message along with the number of accepted spans.
+  ExportTracePartialSuccess details = 1;
+}
+
+message ExportTracePartialSuccess {
+  // The number of accepted spans
+  int64 accepted_spans = 1;
+
+  // A developer-facing human-readable error message in English. It should
+  // both explain the error and offer an actionable resolution to it.
+  string error_message = 2;
 }


### PR DESCRIPTION
An early first attempt in solving/addressing https://github.com/open-telemetry/opentelemetry-specification/issues/2454

Sample apps used as an exercise for backwards compatibility: https://github.com/joaopgrassi/otlp-partial-success-experimental

I tried first having "top-level" properties under the `Export*ServiceRequest` types like so:

```
message ExportMetricsServiceResponse {
  optional int64 accepted_data_points = 1;
  optional string error_message = 2;
}
```

But, in my view this has a drawback. OTLP exporters using the new protos would have to always check the [explicit presence](https://github.com/protocolbuffers/protobuf/blob/main/docs/field_presence.md#presence-in-proto3-apis) of the new fields (e.g. `HasAcceptedDatapoints`) since they don't know which proto version the server is using. Also, since there's not only one field, would it need to check both? What if we add new fields later?

So I thought having a new type that combines these two new fields is a better compromise. This way, it only needs to check if the new field is not null. If it's not null, we can have some guarantee that the other fields are there (we indicate it with a MUST in the spec, for ex)

I did some tests with sample apps to confirm the cases for backwards compatibility:

### 1. Old exporters working with servers using the new protos
All works, as the exporters were not expecting the new fields. They will not have the fields, so they can't inform the user of a partial success - status quo.

### 2. New exporters working with servers using the old protos
Exporters MUST check if the `Details` field is not null to be able to log a message with the details for troubleshooting. 

```csharp
var client = new MetricsService.MetricsServiceClient(channel);
var req = new ExportMetricsServiceRequest();
var response = client.Export(req);

if (response.Details != null)
{
	Console.WriteLine("Number of lines accepted: {0}", response.Details.AcceptedDataPoints);
	Console.WriteLine("Error message: {0}", response.Details.ErrorMessage);
}
```
### 3. New exporters working with servers using the new protos
Since exporters don't know the proto version servers are sending back, it always have to perform the check on point `2` above. 




